### PR TITLE
Update ssh/terminal package path

### DIFF
--- a/cmd/twik/main.go
+++ b/cmd/twik/main.go
@@ -8,7 +8,7 @@ import (
 	"reflect"
 	"strings"
 
-	"code.google.com/p/go.crypto/ssh/terminal"
+	"golang.org/x/crypto/ssh/terminal"
 
 	"gopkg.in/twik.v1"
 )


### PR DESCRIPTION
It moved from code.google.com to golang.org
